### PR TITLE
Updated publications page

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -74,6 +74,8 @@
 
 			<div id="page-body">
 				<h1>Publications</h1>
+
+				<h2>2016</h2>
 				<div id="publication-container-local">
 					<a href="http://arxiv.org/abs/1610.01097">Hourglass dispersion and resonance of magnetic excitations in the superconducting state of the single-layer cuprate HgBa<sub>2</sub>CuO<sub>4+δ</sub> near optimal doping</a>
 					<p>M. K. Chan, Y. Tang, C. J. Dorow, J. Jeong, L. Mangrin-Thro, M. J. Veit, Y. Ge, D. L. Abernathy, Y. Sidis, P. Bourges, M. Greven</p>
@@ -92,10 +94,10 @@
 					<p>Nat. Commun. <strong>7</strong>, 12244 (2016)
 				</div>
 
-				<div id="publication-container-local">
-					<a href="http://arxiv.org/abs/1507.07885">Hidden Fermi-liquid behavior throughout the phase diagram of the cuprates</a>
-					<p>N. Barišić, M. K. Chan, M. J. Veit, C. J. Dorow, Y. Ge, Y. Tang, W. Tabis, G. Yu, X. Zhao, M. Greven</p>
-					<p>arXiv:1507.07885</p>
+				<div id="publication-container-collab">
+					<a href="http://www.nature.com/articles/srep23610">The rate of quasiparticle recombination probes the onset of coherence in cuprate superconductors</a>
+					<p>J.P. Hinton, E. Thewalt, Z. Alpichshev, F. Mahmood, J.D. Koralek, M.K. Chan, M.J. Veit, C.J. Dorow, N. Barisic, A.F. Kemper, D.A. Bonn, W.N. Hardy, Ruixing Liang, N. Gedik, M. Greven, A. Lanzara, J. Orenstein</p>
+					<p>Scientific Reports <strong>6</strong>, 23610 (2016)</p>
 				</div>
 
 				<div id="publication-container-local">
@@ -104,22 +106,30 @@
 					<p>Nat. Commun. <strong>7</strong>, 10819 (2016)</p>
 				</div>
 
+				<h2>2015</h2>
+				<div id="publication-container-collab">
+					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.92.081115">Electronic spin susceptibilities and superconductivity in HgBa<sub>2</sub>CuO<sub>4+δ</sub>3from nuclear magnetic resonance</a>
+					<p>D. Rybicki, J. Kohlrautz, J. Haase, M. Greven, X. Zhao, M. K. Chan, C. Dorow, and M. Veit</p>
+					<p>Phys. Rev. B <strong>92</strong>, 081115(R) (2015)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://arxiv.org/abs/1507.07885">Hidden Fermi-liquid behavior throughout the phase diagram of the cuprates</a>
+					<p>N. Barišić, M. K. Chan, M. J. Veit, C. J. Dorow, Y. Ge, Y. Tang, W. Tabis, G. Yu, X. Zhao, M. Greven</p>
+					<p>arXiv:1507.07885</p>
+				</div>
+
+				<div id="publication-container-collab">
+					<a href="http://www.nature.com/nphys/journal/v11/n5/abs/nphys3265.html">Snapshots of the retarded interaction of charge carriers with ultrafast fluctuations in cuprates</a>
+					<p>S. Dal Conte, L. Vidmar, D. Golež, M. Mierzejewski, G. Soavi, S. Peli, F. Banfi, G.Ferrini, R. Comin, B.M. Ludbrook, L. Chauviere, N.D. Zhigadlo, H. Eisaki, M.Greven, S. Lupi, A. Damascelli, D. Brida, M. Capone, J. Bonča, G. Cerullo, and C. Giannetti</p>
+					<p>Nature Physics <strong>11</strong>, 421 (2015)</p>
+				</div>
+
+				<h2>2014</h2>
 				<div id="publication-container-local">
 					<a href="http://www.nature.com/articles/ncomms6875">Charge order and its connection with Fermi-liquid charge transport in a pristine high-Tc cuprate</a>
 					<p>W. Tabis, Y. Li, M. Le Tacon, L. Braicovich, A. Kreyssig, M. Minola, G. Dellea, E. Weschke, M. J. Veit, M. Ramazanoglu, A. I. Goldman, T. Schmitt, G. Ghiringhelli, N. Barišić, M. K. Chan, C. J. Dorow, G. Yu, X. Zhao, B. Keimer, M. Greven</p>
 					<p>Nat. Commun. <strong>5</strong>, 5875 (2014)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://www.nature.com/nphys/journal/v10/n11/full/nphys3117.html">Asymmetry of collective excitations in electron and hole doped cuprate superconductors</a>
-					<p>W. S. Lee, J. J. Lee, E. A. Nowadnick, W. Tabis, S. W. Huang, V.N. Strocov, E. M. Motoyama, G. Yu, B. Moritz, M. Greven, T. Schmitt, Z. X. Shen, T. P. Devereaux</p>
-					<p>Nat. Phys. <strong>10</strong>, 883 (2014)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.024515">The Strain Derivatives of Tc in HgBa<sub>2</sub>CuO<sub>4+δ</sub>: The CuO<sub>2</sub> Plane Alone is Not Enough</a>
-					<p>S. Wang, J. Zhang, J. Yan, X.-J. Chen, V. Struzhkin, W. Tabis, N. Barišić, M. K. Chan, C. Dorow, X. Zhao, M. Greven, W. L. Mao, and T. Geballe</p>
-					<p>Phys. Rev. B <strong>89</strong>, 024515 (2014)</p>
 				</div>
 
 				<div id="publication-container-local">
@@ -129,247 +139,15 @@
 				</div>
 
 				<div id="publication-container-local">
-					<a href="http://www.nature.com/nphys/journal/vaop/ncurrent/pdf/nphys2792.pdf">Universal quantum oscillations in the underdoped cuprate superconductors</a>
-					<p>N. Barišić, S. Badoux, M. K. Chan, C. Dorow, W. Tabis, B. Vignolle, G. Yu, J. Béard, X. Zhao, C. Proust, M. Greven</p>
-					<p>Nat. Phys. <strong>9</strong>, 761 (2013)</p>
-					<p>see also</p>
-					<a href="http://www.nature.com/nphys/journal/v9/n12/full/nphys2822.html">High-temperature superconductors: Plane speaking</a>
-					<p>News & Views by M. Norman, Nat. Phys. <strong>9</strong>, 757 (2013)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://www.pnas.org/content/110/30/12235.abstract?sid=0b2ffdea-1516-4c63-b749-414c22f92201">Universal sheet resistance and revised phase diagram of the cuprate high-temperature superconductors</a>
-					<p>N. Barišić, M. K. Chan, Y. Li, G. Yu, X. Zhao, M. Dressel, A. Smontara, and M. Greven</p>
-					<p>Proc. Nat. Acad. Sci. <strong>110</strong>, 12235 (2013)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://www.nature.com/nphys/journal/v8/n5/full/nphys2271.html">Two Ising like collective magnetic excitations in a single-layer cuprate superconductor</a>
-					<p>Y. Li, G. Yu, M.K. Chan, V. Balédent, Y. Li, N. N. Barišić, K. Hradil, R.A. Mole, Y. Sidis, P. Steffens, X. Zhao, P. Bourges, and M. Greven</p>
-					<p>Nat. Phys. <strong>8</strong>, 404 (2012)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://iopscience.iop.org/0953-2048/25/11/115010">Temperature and field dependence of the anisotropy parameter for the high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
-					<p>D. D. Xia, G. Yu, X. Zhao, B. Li, X. Liu, L. Ji, M. K. Chan and M. Greven</p>
-					<p>Supercond. Sci. Technol. <strong>25</strong>, 115010 (2012)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://arxiv.org/ftp/arxiv/papers/1210/1210.6942.pdf">Universal superconducting fluctuations and the implications for the phase diagram of the cuprates</a>
-					<p>G. Yu, D.-D. Xia, N. Barišić, R.-H. He, N. Kaneko, T. Sasagawa, Y. Li, X. Zhao, A. Shekhter, M. Greven</p>
-					<p>arXiv:1210.6942</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://prb.aps.org/abstract/PRB/v84/i22/e224508">Magnetic order in the pseudogap phase of HgBa<sub>2</sub>CuO<sub>4+δ</sub> studied by spin-polarized neutron diffraction</a>
-					<p>Y. Li, V. Balédent, N. Barišić,Y.C. Cho, Y. Sidis, G. Yu, X. Zhao, P. Bourges, and M. Greven</p>
-					<p>Phys. Rev. B <strong>84</strong>, 224508 (2011)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://prb.aps.org/abstract/PRB/v83/i5/e054507">Magnetic vortex lattice in HgBa<sub>2</sub>CuO<sub>4+δ</sub> observed by small-angle neutron scattering</a>
-					<p>Y. Li, N. Egetenmeyer, J. L. Gavilano, N. Barišić, M. Greven</p>
-					<p>Phys. Rev. B <strong>83</strong>, 054507 (2011)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://www.nature.com/nature/journal/v468/n7321/full/nature09477.html">Hidden magnetic excitation in the pseudogap phase of a model cuprate superconductor</a>
-					<p>Y. Li, V. Balédent, G. Yu, N. Barišić, K. Hradil, R.A. Mole, Y. Sidis, P. Steffens, X. Zhao, P. Bourges, and M. Greven</p>
-					<p>Nature <strong>468</strong>, 283 (2010)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://prb.aps.org/abstract/PRB/v82/i17/e172505">Spectral weight redistribution and two low-energy scales in the magnetic excitations of the electron-doped superconductor Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4+δ</sub></a>
-					<p>G. Yu, Y. Li, E. M. Motoyama, K. Hradil, R. A. Mole, and M. Greven</p>
-					<p>Phys. Rev. B <strong>82</strong>, 172505 (2010)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://prb.aps.org/abstract/PRB/v81/i6/e064518">Magnetic resonance in the model high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
-					<p>G. Yu, Y. Li, E. M. Motoyama, X. Zhao, N. Barišić, Y. Cho, P. Bourges,K. Hradil, R. A. Mole, and M. Greven</p>
-					<p>Phys. Rev. B <strong>81</strong>, 064518 (2010)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://link.aps.org/doi/10.1103/PhysRevB.82.035113">Polarization dependence and symmetry analysis in indirect K-edge resonant inelastic X-ray scattering (RIXS)</a>
-					<p>G. Chabot-Couture, J.N. Hancock, P.K. Mang, D.M. Casa, T. Gog, and M. Greven</p>
-					<p>Phys. Rev. B <strong>82</strong>, 035113 (2010)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://iopscience.iop.org/1367-2630/12/3/033001">Lattice coupling and Franck-Condon effects in K-edge resonant inelastic X-ray scattering</a>
-					<p>J. N. Hancock, G. Chabot-Couture, and M. Greven</p>
-					<p>New J. Phys. <strong>12</strong>, 033001 (2010)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1038/nphys1426">Universal relation between magnetic resonance and superconducting gap in unconventional superconductors</a>
-					<p>G. Yu, Y. Li, E. M. Motoyama, and M. Greven</p>
-					<p>Nat. Phys. <strong>5</strong>, 873 (2009)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://iopscience.iop.org/1367-2630/11/9/093020">Effect of strong correlations on the high energy anomaly in hole-and electron-doped high-T<sub>c</sub> superconductors</a>
-					<p>B. Moritz, F. Schmitt, W. Meevasana, S. Johnston, E. M. Motoyama, M. Greven, D. H. Lu, C. Kim, R. T. Scalettar, Z-X Shen, and T. P. Devereaux</p>
-					<p>New J. Phys. <strong>11</strong>, 093020 (2009)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://prb.aps.org/abstract/PRB/v80/i9/e092509">Resonant inelastic x-ray scattering in electronically quasi-zero-dimensional CuB<sub>2</sub>O<sub>4</sub></a>
-					<p>J. N. Hancock, G. Chabot-Couture, Y. Li, G. Petrakovskii, K. Ishii, I. Jarrige, J.-i. Mizuki, T. P. Devereaux, and M. Greven</p>
-					<p>Phys. Rev. B <strong>80</strong>, 092509 (2009)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1038/nature07251">Unusual magnetic order in the pseudogap region of the superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
-					<p>Y. Li, V. Balédent, N. Barišić, Y. Cho, B. Fauqué, Y. Sidis, G. Yu, X. Zhao, P. Bourges, and M. Greven</p>
-					<p>Nature <strong>455</strong>, 372 (2008)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://link.aps.org/abstract/PRB/v78/e054518">Demonstrating the model nature of the high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
-					<p>N. Barišić, Y. Li, X. Zhao, Y. C. Cho, G. Chabot-Couture, G. Yu, and M. Greven</p>
-					<p>Phys. Rev. B <strong>78</strong>, 054518 (2008)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1038/nature05437">Spin correlations in the electron-doped high-transition-temperature superconductor Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4+δ</sub></a>
-					<p>E. M. Motoyama, G. Yu, I. M. Vishik, O. P. Vajk, P. K. Mang, and M. Greven</p>
-					<p>Nature <strong>455</strong>, 186 (2007)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1002/adma.200600931">Crystal growth and characterization of the model high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
-					<p>X. Zhao, G. Yu, Y. Cho, G. Chabot-Couture, N. Barišić, P. Bourges, N. Kaneko, Y. Li, L. Lu, E. M. Motoyama, O. P. Vajk and M. Greven </p>
-					<p>Adv. Mater. <strong>18</strong>, 3243 (2006)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.74.144431">Quasistationary criticality of the order parameter of the three-dimensional random-field Ising antiferromagnet Fe<sub>0.85</sub>Zn<sub>0.15</sub>F<sub>2</sub>: A synchrotron x-ray scattering study</a>
-					<p>F. Ye, L. Zhou, S. A. Meyer, L. J. Shelton, D. P. Belanger, L. Lu, S. Larochelle, and M. Greven</p>
-					<p>Phys. Rev. B <strong>74</strong>, 144431 (2006)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.96.137002">Magnetic field effect on the superconducting magnetic gap of Nd<sub>1.85</sub>Ce<sub>0.15</sub>CuO<sub>4</sub></a>
-					<p>E. M. Motoyama, P. K. Mang, D. Petitgrand, G. Yu, O. P. Vajk, I. M. Vishik, and M. Greven</p>
-					<p>Phys. Rev. Lett. <strong>96</strong>, 137002 (2006)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.71.024435">Structural and magnetic properties of the single-layer manganese oxide La<sub>1-x</sub>Sr<sub>1+x</sub>MnO<sub>4</sub></a>
-					<p>S. Larochelle, A. Mehta, L. Lu, P. K. Mang, O. P. Vajk, N. Kaneko, J. W. Lynn, L. Zhou, and M. Greven</p>
-					<p>Phys. Rev. B <strong>71</strong>, 024435 (2005)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.95.217003">Charge-transfer excitations in the model superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
-					<p>L. Lu, X. Zhao, G. Chabot-Couture, J. N. Hancock, N. Kaneko, O. P. Vajk, G. Yu, S. Grenier, Y. J. Kim, D. Casa, T. Gog, and M. Greven</p>
-					<p>Phys. Rev. Lett. <strong>95</strong>, 217003 (2005)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.70.094507">Phase decomposition and chemical inhomogeneity in Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4+δ</sub></a>
-					<p>P. K. Mang, S. Larochelle, A. Mehta, O. P. Vajk, A. S. Erickson, L. Lu, W. J. L. Buyers, A. F. Marshall, K. Prokes, and M. Greven</p>
-					<p>Phys. Rev. B <strong>70</strong>, 094507 (2004)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.69.092408">Susceptibilities and spin gaps of weakly-coupled spin ladders</a>
-					<p>S. Larochelle and M. Greven Phys. Rev. B <strong>69</strong>, 092408 (2004)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.69.064512">Effect of chemical inhomogeneity in the bismuth-based copper oxide superconductors</a>
-					<p>H. Eisaki, N. Kaneko, D. L. Feng, A. Damascelli, P. K. Mang, K. M. Shen, Z.-X. Shen, and M. Greven</p>
-					<p>Phys. Rev. B <strong>69</strong>, 064512 (2004)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.93.027002">Spin correlations and magnetic order in non-superconducting Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4</sub></a>
-					<p>P. K. Mang, O. P. Vajk, A. Arvanitaki, J. W. Lynn, and M. Greven</p>
-					<p>Phys. Rev. Lett. <strong>93</strong>, 027002 (2004)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1142/S0217979203016133">Electron-phonon interaction in n-doped cuprates: an inelastic X-ray scattering study</a>
-					<p>M. d'Astudo, P. K. Mang, P. Giura, A. Shukla, A. Mirone, M. Krisch, F. Sette, P. Ghigna, M. Braden, and M. Greven</p>
-					<p>Int. J. Mod. Phys. B <strong>17</strong>, 484 (2003)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1038/426139b">Spurious magnetism in a high - temperature superconductor</a>
-					<p>P. K. Mang, S. Larochelle, and M. Greven</p>
-					<p>Nature <strong>426</strong>, 139 (2003)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1016/S0038-1098%2802%2900708-1">Neutron scattering, magnetometry, and quantum Monte Carlo study of the randomly-diluted Spin-1/2 square-lattice Heisenberg antiferromagnet</a>
-					<p>O. P. Vajk, M. Greven, P. K. Mang, and J. W. Lynn</p>
-					<p>Solid State Commun. <strong>126</strong>, 93 (2003)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.89.177202">Quantum vs. geometric disorder in a two-dimensional Heisenberg antiferromagnet</a>
-					<p>O. P. Vajk and M. Greven</p>
-					<p>Phys. Rev. Lett. <strong>89</strong>, 177202 (2002)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.89.157202">Order-parameter criticality of the d=3 random-field Ising antiferromagnet Fe<sub>0.85</sub>Zn<sub>0.15</sub>F<sub>2</sub></a>
-					<p>F. Ye, L. Zhou, S. Larochelle, L. Lu, D. P. Belanger, M. Greven, and D. Lederman</p>
-					<p>Phys. Rev. Lett. <strong>89</strong>, 157202 (2002)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.88.167002">Anomalous dispersion of longitudinal optical phonons in Nd<sub>1.86</sub>Ce<sub>0.14</sub>CuO<sub>4+δ</sub>
-						<p>determined by Inelastic X-ray Scattering</a></p>
-						<p>M. d'Astuto, P. K. Mang, P. Giura, A. Shukla, P. Ghigna, A. Mirone, M. Braden, M. Greven, M. Krisch, and F. Sette </p>
-						<p>Phys. Rev. Lett. <strong>88</strong>, 167002 (2002)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.66.184512">Bulk magnetic properties and phase diagram of Li-doped La<sub>2</sub>CuO<sub>4</sub>: common magnetic response of hole-doped CuO<sub>2</sub>
-						<p>planes</a></p>
-						<p>T. Sasagawa, P. K. Mang, O. P. Vajk, A. Kapitulnik, and M. Greven</p>
-						<p>Phys. Rev. B <strong>66</strong>, 184512 (2002)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1016/S0921-4534%2802%2901269-8">Preparation and characterization of homogeneous YBCO single crystals with doping level near the SC-AFM boundary</a>
-					<p>R.-X. Liang, D. A. Bonn, W. N. Hardy, Janice C. Wynn, K. A. Moler, L. Lu, S. Larochelle, L. Zhou, M. Greven, L. Lurio, and S. G. J. Mochrie</p>
-					<p>Physica C <strong>383</strong>, 1 (2002)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1126/science.1067110">Quantum impurities in the two-dimensional spin one-half Heisenberg antiferromagnet</a>
-					<p>O. P. Vajk, P. K. Mang, M. Greven, P. M. Gehring, and J. W. Lynn </p>
-					<p>Science <strong>295</strong>, 1691 (2002)</p>
-				</div>
-
-				<div id="publication-container-local">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.87.095502">Nature of e<sub>g</sub> electron order in La<sub>1-x</sub>Sr<sub>1+x</sub>MnO<sub>4</sub></a>
-					<p>S. Larochelle, A. Mehta, N. Kaneko, P. K. Mang, A. F. Panchula, L. Zhou, J. Arthur, and M. Greven</p>
-					<p>Phys. Rev. Lett. <strong>87</strong>, 095502 (2001)</p>
+					<a href="http://www.nature.com/nphys/journal/v10/n11/full/nphys3117.html">Asymmetry of collective excitations in electron and hole doped cuprate superconductors</a>
+					<p>W. S. Lee, J. J. Lee, E. A. Nowadnick, W. Tabis, S. W. Huang, V.N. Strocov, E. M. Motoyama, G. Yu, B. Moritz, M. Greven, T. Schmitt, Z. X. Shen, T. P. Devereaux</p>
+					<p>Nat. Phys. <strong>10</strong>, 883 (2014)</p>
 				</div>
 
 				<div id="publication-container-collab">
-					<a href="http://www.nature.com/articles/srep23610">The rate of quasiparticle recombination probes the onset of coherence in cuprate superconductors</a>
-					<p>J.P. Hinton, E. Thewalt, Z. Alpichshev, F. Mahmood, J.D. Koralek, M.K. Chan, M.J. Veit, C.J. Dorow, N. Barisic, A.F. Kemper, D.A. Bonn, W.N. Hardy, Ruixing Liang, N. Gedik, M. Greven, A. Lanzara, J. Orenstein</p>
-					<p>Scientific Reports <strong>6</strong>, 23610 (2016)</p>
-				</div>
-
-				<div id="publication-container-collab">
-					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.92.081115">Electronic spin susceptibilities and superconductivity in HgBa<sub>2</sub>CuO<sub>4+δ</sub>3from nuclear magnetic resonance</a>
-					<p>D. Rybicki, J. Kohlrautz, J. Haase, M. Greven, X. Zhao, M. K. Chan, C. Dorow, and M. Veit</p>
-					<p>Phys. Rev. B <strong>92</strong>, 081115(R) (2015)</p>
-				</div>
-
-				<div id="publication-container-collab">
-					<a href="http://www.nature.com/nphys/journal/v11/n5/abs/nphys3265.html">Snapshots of the retarded interaction of charge carriers with ultrafast fluctuations in cuprates</a>
-					<p>S. Dal Conte, L. Vidmar, D. Golež, M. Mierzejewski, G. Soavi, S. Peli, F. Banfi, G.Ferrini, R. Comin, B.M. Ludbrook, L. Chauviere, N.D. Zhigadlo, H. Eisaki, M.Greven, S. Lupi, A. Damascelli, D. Brida, M. Capone, J. Bonča, G. Cerullo, and C. Giannetti</p>
-					<p>Nature Physics <strong>11</strong>, 421 (2015)</p>
+					<a href="http://journals.aps.org/prl/abstract/10.1103/PhysRevLett.113.137001">High-energy Anomaly in the Angle-Resolved Photoemission Spectra of Nd<sub>2-x</sub>Ba<sub>x</sub>CuO<sub>4</sub> : Evidence for a Matrix Element Effect</a>
+						<p>E. D. L. Rienks, M. Ärrälä, M. Lindroos, F. Roth, W. Tabis, G. Yu, M. Greven, J. Fink</p>
+						<p>Phys. Rev. Lett. <strong>113</strong>, 137001 (2014)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -379,23 +157,25 @@
 				</div>
 
 				<div id="publication-container-collab">
-					<a href="http://journals.aps.org/prl/abstract/10.1103/PhysRevLett.113.137001">High-energy Anomaly in the Angle-Resolved Photoemission Spectra of Nd<sub>2-x</sub>Ba<sub>x</sub>CuO<sub>4</sub>
-						<p>: Evidence for a Matrix Element Effect</a></p>
-						<p>E. D. L. Rienks, M. Ärrälä, M. Lindroos, F. Roth, W. Tabis, G. Yu, M. Greven, J. Fink</p>
-						<p>Phys. Rev. Lett. <strong>113</strong>, 137001 (2014)</p>
-				</div>
-
-				<div id="publication-container-collab">
 					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.195141">Angle-resolved photoemission spectroscopy study of HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
 					<p>I. M. Vishik, N. Barišić, M. K. Chan, Y. Li, D. D. Xia, G. Yu, X. Zhao, W. S. Lee, W. Meevasana, T. P. Devereaux, M. Greven, and Z.-X. Shen</p>
 					<p>Phys. Rev. B <strong>89</strong>, 195141 (2014)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://prl.aps.org/abstract/PRL/v111/i18/e187001">Doping-Dependent Photon Scattering Resonance in the Model High-Temperature Superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub>
-						<p>Revealed by Raman Scattering and Optical Ellipsometry</a></p>
-						<p>Yuan Li, M. Le Tacon, Y. Matiks, A. V. Boris, T. Loew, C. T. Lin, Lu Chen, M. K. Chan, C. Dorow, L. Ji, N. Barišić, X. Zhao, M. Greven, and B. Keimer</p>
-						<p>Phys. Rev. Lett. <strong>111</strong>, 187001 (2013)</p>
+				<div id="publication-container-local">
+					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.89.024515">The Strain Derivatives of Tc in HgBa<sub>2</sub>CuO<sub>4+δ</sub>: The CuO<sub>2</sub> Plane Alone is Not Enough</a>
+					<p>S. Wang, J. Zhang, J. Yan, X.-J. Chen, V. Struzhkin, W. Tabis, N. Barišić, M. K. Chan, C. Dorow, X. Zhao, M. Greven, W. L. Mao, and T. Geballe</p>
+					<p>Phys. Rev. B <strong>89</strong>, 024515 (2014)</p>
+				</div>
+
+				<h2>2013</h2>
+				<div id="publication-container-local">
+					<a href="http://www.nature.com/nphys/journal/vaop/ncurrent/pdf/nphys2792.pdf">Universal quantum oscillations in the underdoped cuprate superconductors</a>
+					<p>N. Barišić, S. Badoux, M. K. Chan, C. Dorow, W. Tabis, B. Vignolle, G. Yu, J. Béard, X. Zhao, C. Proust, M. Greven</p>
+					<p>Nat. Phys. <strong>9</strong>, 761 (2013)</p>
+					<p>see also</p>
+					<a href="http://www.nature.com/nphys/journal/v9/n12/full/nphys2822.html">High-temperature superconductors: Plane speaking</a>
+					<p>News & Views by M. Norman, Nat. Phys. <strong>9</strong>, 757 (2013)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -405,10 +185,22 @@
 				</div>
 
 				<div id="publication-container-collab">
+					<a href="http://prl.aps.org/abstract/PRL/v111/i18/e187001">Doping-Dependent Photon Scattering Resonance in the Model High-Temperature Superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub> Revealed by Raman Scattering and Optical Ellipsometry</a>
+						<p>Yuan Li, M. Le Tacon, Y. Matiks, A. V. Boris, T. Loew, C. T. Lin, Lu Chen, M. K. Chan, C. Dorow, L. Ji, N. Barišić, X. Zhao, M. Greven, and B. Keimer</p>
+						<p>Phys. Rev. Lett. <strong>111</strong>, 187001 (2013)</p>
+				</div>
+
+				<div id="publication-container-collab">
 					<a href="http://prx.aps.org/pdf/PRX/v3/i2/e021019">
 						<p>Hall, Seeback and Nernst coefficients of underdoped HgBa<sub>2</sub>CuO<sub>4+δ</sub>: Fermi-surface reconstruction in an archetypal cuprate superconductor</a></p>
 						<p>N. Doiron-Leyraud, S. Lepault, O. Cyr-Choiniere, B. Vignolle, F. Laliberte, J. Chang, N. Barisic, M. K. Chan, L. Ji, X. Zhao, Y. Li, M. Greven, C. Proust, L. Taillefer</p>
 						<p>Phys. Rev. X <strong>3</strong>, 021019 (2013)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://www.pnas.org/content/110/30/12235.abstract?sid=0b2ffdea-1516-4c63-b749-414c22f92201">Universal sheet resistance and revised phase diagram of the cuprate high-temperature superconductors</a>
+					<p>N. Barišić, M. K. Chan, Y. Li, G. Yu, X. Zhao, M. Dressel, A. Smontara, and M. Greven</p>
+					<p>Proc. Nat. Acad. Sci. <strong>110</strong>, 12235 (2013)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -429,6 +221,19 @@
 					<p>Proc. Natl. Acad. Sci. <strong>110</strong>, 5774 (2013)</p>
 				</div>
 
+				<h2>2012</h2>
+				<div id="publication-container-local">
+					<a href="http://arxiv.org/ftp/arxiv/papers/1210/1210.6942.pdf">Universal superconducting fluctuations and the implications for the phase diagram of the cuprates</a>
+					<p>G. Yu, D.-D. Xia, N. Barišić, R.-H. He, N. Kaneko, T. Sasagawa, Y. Li, X. Zhao, A. Shekhter, M. Greven</p>
+					<p>arXiv:1210.6942</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://iopscience.iop.org/0953-2048/25/11/115010">Temperature and field dependence of the anisotropy parameter for the high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
+					<p>D. D. Xia, G. Yu, X. Zhao, B. Li, X. Liu, L. Ji, M. K. Chan and M. Greven</p>
+					<p>Supercond. Sci. Technol. <strong>25</strong>, 115010 (2012)</p>
+				</div>
+
 				<div id="publication-container-collab">
 					<a href="http://arxiv.org/abs/1208.4690">63Cu and 199Hg NMR study of HgBa<sub>2</sub>CuO<sub>4+δ</sub> single crystals</a>
 					<p>D. Rybicki, J. Haase, M. Lux, M. Jurkutat, M. Greven, G. Yu, Y. Li, X. Zhao</p>
@@ -442,15 +247,34 @@
 				</div>
 
 				<div id="publication-container-collab">
+					<a href="http://www.sciencemag.org/content/335/6076/1600">Disentangling the Electronic and Phononic Glue in a High-Tc Superconductor</a>
+					<p>S. Dal Conte, C. Giannetti, G. Coslovich, F. Cilento, D. Bossini, T. Abebaw, F. Banfi, G. Ferrini, H. Eisaki, M. Greven, A. Damascelli, D. van der Marel, F. Parmigiani</p>
+					<p>Science <strong>335</strong>, 6076 (2012)</p>
+				</div>
+
+				<div id="publication-container-collab">
 					<a href="http://link.aps.org/doi/10.1103/PhysRevB.85.104517">Two-component uniform spin susceptibility of superconducting HgBa2CuO4+δ single crystals measured using Cu-63 and Hg-199 nuclear magnetic resonance</a>
 					<p>J. Haase, D. Rybicki, C.P. Slichter, M. Greven, G. Yu, Y. Li, and X. Zhao</p>
 					<p>Phys. Rev. B <strong>85</strong>, 104517 (2012)</p>
 				</div>
 
+				<div id="publication-container-local">
+					<a href="http://www.nature.com/nphys/journal/v8/n5/full/nphys2271.html">Two Ising like collective magnetic excitations in a single-layer cuprate superconductor</a>
+					<p>Y. Li, G. Yu, M.K. Chan, V. Balédent, Y. Li, N. N. Barišić, K. Hradil, R.A. Mole, Y. Sidis, P. Steffens, X. Zhao, P. Bourges, and M. Greven</p>
+					<p>Nat. Phys. <strong>8</strong>, 404 (2012)</p>
+				</div>
+
+				<h2>2011</h2>
+				<div id="publication-container-local">
+					<a href="http://prb.aps.org/abstract/PRB/v84/i22/e224508">Magnetic order in the pseudogap phase of HgBa<sub>2</sub>CuO<sub>4+δ</sub> studied by spin-polarized neutron diffraction</a>
+					<p>Y. Li, V. Balédent, N. Barišić,Y.C. Cho, Y. Sidis, G. Yu, X. Zhao, P. Bourges, and M. Greven</p>
+					<p>Phys. Rev. B <strong>84</strong>, 224508 (2011)</p>
+				</div>
+
 				<div id="publication-container-collab">
-					<a href="http://www.sciencemag.org/content/335/6076/1600">Disentangling the Electronic and Phononic Glue in a High-Tc Superconductor</a>
-					<p>S. Dal Conte, C. Giannetti, G. Coslovich, F. Cilento, D. Bossini, T. Abebaw, F. Banfi, G. Ferrini, H. Eisaki, M. Greven, A. Damascelli, D. van der Marel, F. Parmigiani</p>
-					<p>Science <strong>335</strong>, 6076 (2012)</p>
+					<a href="http://link.aps.org/doi/10.1103/PhysRevB.84.144523">Pair breaking versus symmetry breaking: Origin of the Raman modes in superconducting cuprates</a>
+					<p>N. Munnikes, B. Muschler, F. Venturini, L. Tassini, W. Prestel, Shimpei Ono, Yoichi Ando, D. C. Peets, W. N. Hardy, Ruixing Liang, D. A. Bonn, A. Damascelli, H. Eisaki, M. Greven, A. Erb, R. Hackl</p>
+					<p>Phys. Rev. B <strong>84</strong>, 144523 (2011)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -460,7 +284,7 @@
 				</div>
 
 				<div id="publication-container-collab">
-					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.83.195123">High-energy anomaly in Nd2−xCexCuO4 investigated by angle-resolved photoemission spectroscopy and quantum Monte Carlo simulations in overdoped Bi<sub>2</sub>Sr<sub>2</sub>Ca<sub>0.92</sub>Y<sub>0.08</sub>Cu<sub>2</sub>O<sub>8+δ</sub></a>
+					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.83.195123">High-energy anomaly in Nd2−xCexCuO4 investigated by angle-resolved photoemission spectroscopy and quantum Monte Carlo simulations in overdoped Bi<sub>2</sub>Sr<sub>2</sub>Ca<sub>0.92</sub>Y<sub>0.08</sub>Cu<sub>2</sub>O<sub>8+δ</sub></a>
 					<p>F. Schmitt, B. Moritz, S. Johnston, S.-K. Mo, M. Hashimoto, R. G. Moore, D.-H. Lu, E. Motoyama, M. Greven, T. P. Devereaux, and Z.-X. Shen A. Damascelli, and F. Parmigiani</p>
 					<p>Phys. Rev. B <strong>83</strong>, 195123 (2011)</p>
 				</div>
@@ -471,10 +295,23 @@
 					<p>Phys. Rev. B <strong>83</strong>, 064519 (2011)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://link.aps.org/doi/10.1103/PhysRevB.84.144523">Pair breaking versus symmetry breaking: Origin of the Raman modes in superconducting cuprates</a>
-					<p>N. Munnikes, B. Muschler, F. Venturini, L. Tassini, W. Prestel, Shimpei Ono, Yoichi Ando, D. C. Peets, W. N. Hardy, Ruixing Liang, D. A. Bonn, A. Damascelli, H. Eisaki, M. Greven, A. Erb, R. Hackl</p>
-					<p>Phys. Rev. B <strong>84</strong>, 144523 (2011)</p>
+				<div id="publication-container-local">
+					<a href="http://prb.aps.org/abstract/PRB/v83/i5/e054507">Magnetic vortex lattice in HgBa<sub>2</sub>CuO<sub>4+δ</sub> observed by small-angle neutron scattering</a>
+					<p>Y. Li, N. Egetenmeyer, J. L. Gavilano, N. Barišić, M. Greven</p>
+					<p>Phys. Rev. B <strong>83</strong>, 054507 (2011)</p>
+				</div>
+
+				<h2>2010</h2>
+				<div id="publication-container-local">
+					<a href="http://prb.aps.org/abstract/PRB/v82/i17/e172505">Spectral weight redistribution and two low-energy scales in the magnetic excitations of the electron-doped superconductor Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4+δ</sub></a>
+					<p>G. Yu, Y. Li, E. M. Motoyama, K. Hradil, R. A. Mole, and M. Greven</p>
+					<p>Phys. Rev. B <strong>82</strong>, 172505 (2010)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://www.nature.com/nature/journal/v468/n7321/full/nature09477.html">Hidden magnetic excitation in the pseudogap phase of a model cuprate superconductor</a>
+					<p>Y. Li, V. Balédent, G. Yu, N. Barišić, K. Hradil, R.A. Mole, Y. Sidis, P. Steffens, X. Zhao, P. Bourges, and M. Greven</p>
+					<p>Nature <strong>468</strong>, 283 (2010)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -489,10 +326,41 @@
 					<p>Phys. Rev. Lett. <strong>105</strong>, 167002 (2010)</p>
 				</div>
 
+				<div id="publication-container-local">
+					<a href="http://link.aps.org/doi/10.1103/PhysRevB.82.035113">Polarization dependence and symmetry analysis in indirect K-edge resonant inelastic X-ray scattering (RIXS)</a>
+					<p>G. Chabot-Couture, J.N. Hancock, P.K. Mang, D.M. Casa, T. Gog, and M. Greven</p>
+					<p>Phys. Rev. B <strong>82</strong>, 035113 (2010)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://iopscience.iop.org/1367-2630/12/3/033001">Lattice coupling and Franck-Condon effects in K-edge resonant inelastic X-ray scattering</a>
+					<p>J. N. Hancock, G. Chabot-Couture, and M. Greven</p>
+					<p>New J. Phys. <strong>12</strong>, 033001 (2010)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://prb.aps.org/abstract/PRB/v81/i6/e064518">Magnetic resonance in the model high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
+					<p>G. Yu, Y. Li, E. M. Motoyama, X. Zhao, N. Barišić, Y. Cho, P. Bourges,K. Hradil, R. A. Mole, and M. Greven</p>
+					<p>Phys. Rev. B <strong>81</strong>, 064518 (2010)</p>
+				</div>
+
 				<div id="publication-container-collab">
 					<a href="http://iopscience.iop.org/1742-6596/234/1/012024">Flux Creep Relaxation in Single Crystal Hg-1201</a>
 					<p>M. Baenitz, K. Lüders, N. Barišić, Y. Cho,, Y. Li, G. Yu, X. Zhao, and M. Greven</p>
 					<p>J. Phys. Conf. Ser. <strong>234</strong>, 012024 (2010)</p>
+				</div>
+
+				<h2>2009</h2>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1038/nphys1426">Universal relation between magnetic resonance and superconducting gap in unconventional superconductors</a>
+					<p>G. Yu, Y. Li, E. M. Motoyama, and M. Greven</p>
+					<p>Nat. Phys. <strong>5</strong>, 873 (2009)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://prb.aps.org/abstract/PRB/v80/i9/e092509">Resonant inelastic x-ray scattering in electronically quasi-zero-dimensional CuB<sub>2</sub>O<sub>4</sub></a>
+					<p>J. N. Hancock, G. Chabot-Couture, Y. Li, G. Petrakovskii, K. Ishii, I. Jarrige, J.-i. Mizuki, T. P. Devereaux, and M. Greven</p>
+					<p>Phys. Rev. B <strong>80</strong>, 092509 (2009)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -504,22 +372,10 @@
 					<p>Physica C <strong>240</strong>, S228 (2010)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://prb.aps.org/abstract/PRB/v79/i22/e224502">Discontinuity of the ultrafast electronic response of underdoped superconducting Bi<sub>2</sub>Sr<sub>2</sub>CaCuO<sub>8+δ</sub> strongly excited by ultrashort light pulses</a>
-					<p>C. Giannetti, G. Coslovich, F. Cilento, G. Ferrini, H. Eisaki, N. Kaneko, M. Greven, and F. </p>
-					<p>Phys. Rev. B <strong>79</strong>, 224502 (2009)</p>
-				</div>
-
-				<div id="publication-container-collab">
-					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.79.184512">Optical determination of the relation between the electron-boson coupling function and the critical temperature in high-Tc cuprates</a>
-					<p>E. van Heumen, E. Muhlethaler, A.B. Kuzmenko, H. Eisaki, W. Meevasana, M. Greven, D. van der Marel</p>
-					<p>Phys. Rev. B <strong>79</strong>, 184512 (2009)</p>
-				</div>
-
-				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1016/j.physc.2009.05.203">Vortex dynamics in single crystal Hg-1201</a>
-					<p>M. Baenitz, K. Lüders, D. Maurer, N. Barišić, Y. Cho, Y. Li, G. Yu, X. Zhao, and M. Greven </p>
-					<p>Physica C <strong>469</strong>, 1126 (2009)</p>
+				<div id="publication-container-local">
+					<a href="http://iopscience.iop.org/1367-2630/11/9/093020">Effect of strong correlations on the high energy anomaly in hole-and electron-doped high-T<sub>c</sub> superconductors</a>
+					<p>B. Moritz, F. Schmitt, W. Meevasana, S. Johnston, E. M. Motoyama, M. Greven, D. H. Lu, C. Kim, R. T. Scalettar, Z-X Shen, and T. P. Devereaux</p>
+					<p>New J. Phys. <strong>11</strong>, 093020 (2009)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -529,9 +385,40 @@
 				</div>
 
 				<div id="publication-container-collab">
+					<a href="http://prb.aps.org/abstract/PRB/v79/i22/e224502">Discontinuity of the ultrafast electronic response of underdoped superconducting Bi<sub>2</sub>Sr<sub>2</sub>CaCuO<sub>8+δ</sub> strongly excited by ultrashort light pulses</a>
+					<p>C. Giannetti, G. Coslovich, F. Cilento, G. Ferrini, H. Eisaki, N. Kaneko, M. Greven, and F. </p>
+					<p>Phys. Rev. B <strong>79</strong>, 224502 (2009)</p>
+				</div>
+
+				<div id="publication-container-collab">
+					<a href="http://dx.doi.org/10.1016/j.physc.2009.05.203">Vortex dynamics in single crystal Hg-1201</a>
+					<p>M. Baenitz, K. Lüders, D. Maurer, N. Barišić, Y. Cho, Y. Li, G. Yu, X. Zhao, and M. Greven </p>
+					<p>Physica C <strong>469</strong>, 1126 (2009)</p>
+				</div>
+
+				<div id="publication-container-collab">
+					<a href="http://journals.aps.org/prb/abstract/10.1103/PhysRevB.79.184512">Optical determination of the relation between the electron-boson coupling function and the critical temperature in high-Tc cuprates</a>
+					<p>E. van Heumen, E. Muhlethaler, A.B. Kuzmenko, H. Eisaki, W. Meevasana, M. Greven, D. van der Marel</p>
+					<p>Phys. Rev. B <strong>79</strong>, 184512 (2009)</p>
+				</div>
+
+				<div id="publication-container-collab">
 					<a href="http://dx.doi.org/10.1007/s10948-008-0376-2">Spatial inhomogeneities in single-crystal HgBa<sub>2</sub>CuO<sub>4+δ</sub> from <sup>63</sup>Cu NMR spin and quadrupole shifts</a>
 					<p>D. Rybicki, J. Haase, M. Greven, G. Yu, Y. Li, Y. Cho, and X. Zhao</p>
 					<p>J. Supercond. Novel Magn.  <strong>22</strong>, 179 (2009)</p>
+				</div>
+
+				<h2>2008</h2>
+				<div id="publication-container-collab">
+					<a href="http://arxiv.org/abs/0807.1730">Observation of a robust peak in the glue function of the high Tc cuprates in the 50-60 meV range</a>
+					<p>E. van Heumen, E. Muhlethaler, A.B. Kuzmenko, D. van der Marel, H. Eisaki, M. Greven, W. Meevasana, Z.X. Shen</p>
+					<p>arXiv:0807.1730</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1038/nature07251">Unusual magnetic order in the pseudogap region of the superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
+					<p>Y. Li, V. Balédent, N. Barišić, Y. Cho, B. Fauqué, Y. Sidis, G. Yu, X. Zhao, P. Bourges, and M. Greven</p>
+					<p>Nature <strong>455</strong>, 372 (2008)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -540,12 +427,13 @@
 					<p>Phys. Rev. B <strong>78</strong>, 100505(R) (2008)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://arxiv.org/abs/0807.1730">Observation of a robust peak in the glue function of the high Tc cuprates in the 50-60 meV range</a>
-					<p>E. van Heumen, E. Muhlethaler, A.B. Kuzmenko, D. van der Marel, H. Eisaki, M. Greven, W. Meevasana, Z.X. Shen</p>
-					<p>arXiv:0807.1730</p>
+				<div id="publication-container-local">
+					<a href="http://link.aps.org/abstract/PRB/v78/e054518">Demonstrating the model nature of the high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
+					<p>N. Barišić, Y. Li, X. Zhao, Y. C. Cho, G. Chabot-Couture, G. Yu, and M. Greven</p>
+					<p>Phys. Rev. B <strong>78</strong>, 054518 (2008)</p>
 				</div>
 
+				<h2>2007</h2>
 				<div id="publication-container-collab">
 					<a href="http://dx.doi.org/10.1103/PhysRevB.75.054522">Optical and thermodynamic properties of the high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
 					<p>E. van Heumen, R. Lortz, A. B. Kuzmenko, F. Carbone, D. van der Marel, X. Zhao, G. Yu, Y. Cho, N. Barišić, M. Greven, C. C. Homes, and S. V. Dordevic</p>
@@ -556,6 +444,37 @@
 					<a href="http://dx.doi.org/10.1103/PhysRevB.75.054511">Muon spin relaxation study of superconducting Bi<sub>2</sub>Sr<sub>2-x</sub>La<sub>x</sub>CuO<sub>6+δ</sub>(Bi2201)</a>
 					<p>P. L. Russo, C. R. Wiebe, Y. J. Uemura, A. T. Savici, G. J. MacDougall, J. Rodriguez, G. M. Luke, N. Kaneko, H. Eisaki, M. Greven, O. P. Vajk, S. Ono, Yoichi Ando, K. Fujita, K. M. Kojima and S. Uchida </p>
 					<p>Phys. Rev. B <strong>75</strong>, 054511 (2007)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1038/nature05437">Spin correlations in the electron-doped high-transition-temperature superconductor Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4+δ</sub></a>
+					<p>E. M. Motoyama, G. Yu, I. M. Vishik, O. P. Vajk, P. K. Mang, and M. Greven</p>
+					<p>Nature <strong>455</strong>, 186 (2007)</p>
+				</div>
+
+				<h2>2006</h2>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1002/adma.200600931">Crystal growth and characterization of the model high-temperature superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
+					<p>X. Zhao, G. Yu, Y. Cho, G. Chabot-Couture, N. Barišić, P. Bourges, N. Kaneko, Y. Li, L. Lu, E. M. Motoyama, O. P. Vajk and M. Greven </p>
+					<p>Adv. Mater. <strong>18</strong>, 3243 (2006)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevB.74.144431">Quasistationary criticality of the order parameter of the three-dimensional random-field Ising antiferromagnet Fe<sub>0.85</sub>Zn<sub>0.15</sub>F<sub>2</sub>: A synchrotron x-ray scattering study</a>
+					<p>F. Ye, L. Zhou, S. A. Meyer, L. J. Shelton, D. P. Belanger, L. Lu, S. Larochelle, and M. Greven</p>
+					<p>Phys. Rev. B <strong>74</strong>, 144431 (2006)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.96.137002">Magnetic field effect on the superconducting magnetic gap of Nd<sub>1.85</sub>Ce<sub>0.15</sub>CuO<sub>4</sub></a>
+					<p>E. M. Motoyama, P. K. Mang, D. Petitgrand, G. Yu, O. P. Vajk, I. M. Vishik, and M. Greven</p>
+					<p>Phys. Rev. Lett. <strong>96</strong>, 137002 (2006)</p>
+				</div>
+
+				<div id="publication-container-collab">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.96.017007">Gap-inhomogeneity-induced electronic states in superconducting Bi<sub>2</sub>Sr<sub>2</sub>CaCu<sub>2</sub>O<sub>8+δ</sub></a>
+					<p>A. C. Fang, L. Capriotti, D. J. Scalapino, S. A. Kivelson, N. Kaneko, M. Greven, and  A. Kapitulnik </p>
+					<p>Phys. Rev. Lett. <strong>96</strong>, 017007 (2006)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -570,10 +489,11 @@
 					<p>J. Phys. Chem. Solids <strong>67</strong>, 239 (2006)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.96.017007">Gap-inhomogeneity-induced electronic states in superconducting Bi<sub>2</sub>Sr<sub>2</sub>CaCu<sub>2</sub>O<sub>8+δ</sub></a>
-					<p>A. C. Fang, L. Capriotti, D. J. Scalapino, S. A. Kivelson, N. Kaneko, M. Greven, and  A. Kapitulnik </p>
-					<p>Phys. Rev. Lett. <strong>96</strong>, 017007 (2006)</p>
+				<h2>2005</h2>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.95.217003">Charge-transfer excitations in the model superconductor HgBa<sub>2</sub>CuO<sub>4+δ</sub></a>
+					<p>L. Lu, X. Zhao, G. Chabot-Couture, J. N. Hancock, N. Kaneko, O. P. Vajk, G. Yu, S. Grenier, Y. J. Kim, D. Casa, T. Gog, and M. Greven</p>
+					<p>Phys. Rev. Lett. <strong>95</strong>, 217003 (2005)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -582,22 +502,75 @@
 					<p>Phys. Rev. Lett. <strong>95</strong>, 157001 (2005)</p>
 				</div>
 
+				<!-- The manuscript below was in a section called "Manuscripts Based on Samples Grown in our Lab or on our former Magnet Facility at the Stanford Synchrotron Radiation Lightsource" -->
+
 				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1038/nature02673">A universal scaling relation in high-temperature superconductors</a>
-					<p>C. C. Homes, S. V. Dordevic, M. Strongin, D. A. Bonn, R. Liang, W. N. Hardy, Seiki Komiya, Yoichi Ando, G. Yu, N. Kaneko, X. Zhao, M. Greven, D. N. Basov, and T. Timusk </p>
-					<p>Nature <strong>430</strong>, 539 (2004)</p>
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.95.106401">Universal relationship between magnetization and changes in the local structure of La<sub>1-x</sub>Ca<sub>x</sub>MnO<sub>3</sub>: evidence for magnetic dimers</a>
+					<p>L. Downward, F. Bridges, S. Bushart, J. J. Neumeier, N. Dilley, and L. Zhou </p>
+					<p>Phys. Rev. Lett. <strong>95</strong>, 106401 (2005)</p>
 				</div>
 
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevB.71.024435">Structural and magnetic properties of the single-layer manganese oxide La<sub>1-x</sub>Sr<sub>1+x</sub>MnO<sub>4</sub></a>
+					<p>S. Larochelle, A. Mehta, L. Lu, P. K. Mang, O. P. Vajk, N. Kaneko, J. W. Lynn, L. Zhou, and M. Greven</p>
+					<p>Phys. Rev. B <strong>71</strong>, 024435 (2005)</p>
+				</div>
+
+				<h2>2004</h2>
 				<div id="publication-container-collab">
 					<a href="http://dx.doi.org/10.1103/PhysRevB.70.214514">Periodic coherence-peak height modulations in superconducting Bi<sub>2</sub>Sr<sub>2</sub>CaCu<sub>2</sub>O<sub>8+δ</sub></a>
 					<p>A. Fang, C. Howald, N. Kaneko, M. Greven, and  A. Kapitulnik </p>
 					<p>Phys. Rev. B <strong>70</strong>, 214514 (2004)</p>
 				</div>
 
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevB.70.094507">Phase decomposition and chemical inhomogeneity in Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4+δ</sub></a>
+					<p>P. K. Mang, S. Larochelle, A. Mehta, O. P. Vajk, A. S. Erickson, L. Lu, W. J. L. Buyers, A. F. Marshall, K. Prokes, and M. Greven</p>
+					<p>Phys. Rev. B <strong>70</strong>, 094507 (2004)</p>
+				</div>
+
+				<div id="publication-container-collab">
+					<a href="http://dx.doi.org/10.1038/nature02673">A universal scaling relation in high-temperature superconductors</a>
+					<p>C. C. Homes, S. V. Dordevic, M. Strongin, D. A. Bonn, R. Liang, W. N. Hardy, Seiki Komiya, Yoichi Ando, G. Yu, N. Kaneko, X. Zhao, M. Greven, D. N. Basov, and T. Timusk </p>
+					<p>Nature <strong>430</strong>, 539 (2004)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.93.027002">Spin correlations and magnetic order in non-superconducting Nd<sub>2-x</sub>Ce<sub>x</sub>CuO<sub>4</sub></a>
+					<p>P. K. Mang, O. P. Vajk, A. Arvanitaki, J. W. Lynn, and M. Greven</p>
+					<p>Phys. Rev. Lett. <strong>93</strong>, 027002 (2004)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevB.69.092408">Susceptibilities and spin gaps of weakly-coupled spin ladders</a>
+					<p>S. Larochelle and M. Greven Phys. Rev. B <strong>69</strong>, 092408 (2004)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevB.69.064512">Effect of chemical inhomogeneity in the bismuth-based copper oxide superconductors</a>
+					<p>H. Eisaki, N. Kaneko, D. L. Feng, A. Damascelli, P. K. Mang, K. M. Shen, Z.-X. Shen, and M. Greven</p>
+					<p>Phys. Rev. B <strong>69</strong>, 064512 (2004)</p>
+				</div>
+
+				<!-- The manuscript below was in a section called "Manuscripts Based on Samples Grown in our Lab or on our former Magnet Facility at the Stanford Synchrotron Radiation Lightsource" -->
+
+				<div id="publication-container-collab">
+					<a href="http://dx.doi.org/10.1038/nature02347">High-transition-temperature superconductivity in the absence of the magnetic-resonance mode</a>
+					<p>J. Hwang, T. Timusk, and G. D. Gu</p>
+					<p>Nature <strong>427</strong>, 714 (2004)</p>
+				</div>
+
 				<div id="publication-container-collab">
 					<a href="http://dx.doi.org/10.1103/PhysRevB.69.054503">Fully gapped single-particle excitations in the lightly doped cuprates</a>
 					<p>K. M. Shen, T. Yoshida, D. H. Lu, F. Ronning, N. P. Armitage, W. S. Lee, X. J. Zhou, A. Damescelli, D. L. Feng, N. J. C. Ingle, H. Eisaki, Y. Kohsaka, H. Takagi, T. Kakeshita, S. Uchida, P. K. Mang, M. Greven, Y. Onose, Y. Taguchi, Y Tokura, S. Komiya, Y. Ando, M. Azuma, M. Takano, A. Fujimori, Z.-X. Shen</p>
 					<p>Phys. Rev. B <strong>69</strong>, 054503 (2004)</p>
+				</div>
+
+				<h2>2003</h2>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1038/426139b">Spurious magnetism in a high - temperature superconductor</a>
+					<p>P. K. Mang, S. Larochelle, and M. Greven</p>
+					<p>Nature <strong>426</strong>, 139 (2003)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -612,16 +585,41 @@
 					<p>Phys. Rev. B <strong>68</strong>, 064517 (2003)</p>
 				</div>
 
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1142/S0217979203016133">Electron-phonon interaction in n-doped cuprates: an inelastic X-ray scattering study</a>
+					<p>M. d'Astudo, P. K. Mang, P. Giura, A. Shukla, A. Mirone, M. Krisch, F. Sette, P. Ghigna, M. Braden, and M. Greven</p>
+					<p>Int. J. Mod. Phys. B <strong>17</strong>, 484 (2003)</p>
+				</div>
+
 				<div id="publication-container-collab">
 					<a href="http://dx.doi.org/10.1103/PhysRevB.67.014533">Periodic density-of-states modulations in superconducting Bi<sub>2</sub>Sr<sub>2</sub>CaCu<sub>2</sub>O<sub>8+<i>δ</i></sub></a>
 					<p>C. Howald, H. Eisaki, N. Kaneko, M. Greven, and A. Kapitulnik</p>
 					<p>Phys. Rev. B <strong>67</strong>, 014533 (2003)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1103/PhysRevB.65.220501">Electronic excitations near the Brillouin zone boundary of Bi<sub>2</sub>Sr<sub>2</sub>CaCu<sub>2</sub>O<sub>8+δ</sub></a>
-					<p>D. L. Feng, C. Kim, H. Eisaki, D. H. Lu, A. Damascelli, K. M. Shen, F. Ronning, N. P. Armitage, N. Kaneko, M. Greven, J.-I. Shimoyama, K. Kishio, R. Yoshizaki, G. D. Gu, and Z.-X. Shen</p>
-					<p>Phys. Rev. B <strong>65</strong>, 220501 (2002)</p>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1016/S0038-1098%2802%2900708-1">Neutron scattering, magnetometry, and quantum Monte Carlo study of the randomly-diluted Spin-1/2 square-lattice Heisenberg antiferromagnet</a>
+					<p>O. P. Vajk, M. Greven, P. K. Mang, and J. W. Lynn</p>
+					<p>Solid State Commun. <strong>126</strong>, 93 (2003)</p>
+				</div>
+
+				<h2>2002</h2>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevB.66.184512">Bulk magnetic properties and phase diagram of Li-doped La<sub>2</sub>CuO<sub>4</sub>: common magnetic response of hole-doped CuO<sub>2</sub> planes</a>
+						<p>T. Sasagawa, P. K. Mang, O. P. Vajk, A. Kapitulnik, and M. Greven</p>
+						<p>Phys. Rev. B <strong>66</strong>, 184512 (2002)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.89.177202">Quantum vs. geometric disorder in a two-dimensional Heisenberg antiferromagnet</a>
+					<p>O. P. Vajk and M. Greven</p>
+					<p>Phys. Rev. Lett. <strong>89</strong>, 177202 (2002)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.89.157202">Order-parameter criticality of the d=3 random-field Ising antiferromagnet Fe<sub>0.85</sub>Zn<sub>0.15</sub>F<sub>2</sub></a>
+					<p>F. Ye, L. Zhou, S. Larochelle, L. Lu, D. P. Belanger, M. Greven, and D. Lederman</p>
+					<p>Phys. Rev. Lett. <strong>89</strong>, 157202 (2002)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -631,9 +629,9 @@
 				</div>
 
 				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.88.107001">Electronic structure of the trilayer cuprate superconductor Bi<sub>2</sub>Sr<sub>2</sub>Ca<sub>2</sub>Cu<sub>3</sub>O<sub>10+δ</sub></a>
-					<p>D.-L. Feng, A. Damascelli, K.-M. Shen, N. Motoyama, D.-H. Lu, H. Eisaki, K. Shimizu, J.-I. Shimoyama, K. Kishio, N. Kaneko, M. Greven, G.-D. Gu, X.-J. Zhou, C. Kim, F. Ronning, N. P. Armitage, and Z.-X Shen</p>
-					<p>Phys. Rev. Lett. <strong>88</strong>, 107001 (2002)</p>
+					<a href="http://dx.doi.org/10.1103/PhysRevB.65.220501">Electronic excitations near the Brillouin zone boundary of Bi<sub>2</sub>Sr<sub>2</sub>CaCu<sub>2</sub>O<sub>8+δ</sub></a>
+					<p>D. L. Feng, C. Kim, H. Eisaki, D. H. Lu, A. Damascelli, K. M. Shen, F. Ronning, N. P. Armitage, N. Kaneko, M. Greven, J.-I. Shimoyama, K. Kishio, R. Yoshizaki, G. D. Gu, and Z.-X. Shen</p>
+					<p>Phys. Rev. B <strong>65</strong>, 220501 (2002)</p>
 				</div>
 
 				<div id="publication-container-collab">
@@ -642,25 +640,43 @@
 					<p>Int. J. Mod. Phys. B <strong>16</strong>, 1691 (2002)</p>
 				</div>
 
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1016/S0921-4534%2802%2901269-8">Preparation and characterization of homogeneous YBCO single crystals with doping level near the SC-AFM boundary</a>
+					<p>R.-X. Liang, D. A. Bonn, W. N. Hardy, Janice C. Wynn, K. A. Moler, L. Lu, S. Larochelle, L. Zhou, M. Greven, L. Lurio, and S. G. J. Mochrie</p>
+					<p>Physica C <strong>383</strong>, 1 (2002)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.88.167002">Anomalous dispersion of longitudinal optical phonons in Nd<sub>1.86</sub>Ce<sub>0.14</sub>CuO<sub>4+δ</sub> determined by Inelastic X-ray Scattering</a>
+						<p>M. d'Astuto, P. K. Mang, P. Giura, A. Shukla, P. Ghigna, A. Mirone, M. Braden, M. Greven, M. Krisch, and F. Sette </p>
+						<p>Phys. Rev. Lett. <strong>88</strong>, 167002 (2002)</p>
+				</div>
+
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1126/science.1067110">Quantum impurities in the two-dimensional spin one-half Heisenberg antiferromagnet</a>
+					<p>O. P. Vajk, P. K. Mang, M. Greven, P. M. Gehring, and J. W. Lynn </p>
+					<p>Science <strong>295</strong>, 1691 (2002)</p>
+				</div>
+
+				<div id="publication-container-collab">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.88.107001">Electronic structure of the trilayer cuprate superconductor Bi<sub>2</sub>Sr<sub>2</sub>Ca<sub>2</sub>Cu<sub>3</sub>O<sub>10+δ</sub></a>
+					<p>D.-L. Feng, A. Damascelli, K.-M. Shen, N. Motoyama, D.-H. Lu, H. Eisaki, K. Shimizu, J.-I. Shimoyama, K. Kishio, N. Kaneko, M. Greven, G.-D. Gu, X.-J. Zhou, C. Kim, F. Ronning, N. P. Armitage, and Z.-X Shen</p>
+					<p>Phys. Rev. Lett. <strong>88</strong>, 107001 (2002)</p>
+				</div>
+
+				<h2>2001</h2>
 				<div id="publication-container-collab">
 					<a href="http://dx.doi.org/10.1103/PhysRevLett.87.147003">Anomalous electronic structure and pseudogap effects in Nd<sub>1.85</sub>Ce<sub>0.15</sub>CuO<sub>4</sub></a>
 					<p>N. P. Armitage, D.-H. Lu, C. Kim, A. Damascelli, K.-M. Shen, F. Ronning, D.-L. Feng, P. Bogdanov, Z.-X. Shen, Y. Onose, Y. Taguchi, Y. Tokura, P. K. Mang, N. Kaneko, and M. Greven</p>
 					<p>Phys. Rev. Lett. <strong>87</strong>, 147003 (2001)</p>
 				</div>
 
-				<!-- The two manuscripts below were in a section called "Manuscripts Based on Samples Grown in our Lab or on our former Magnet Facility at the Stanford Synchrotron Radiation Lightsource" -->
-
-				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1103/PhysRevLett.95.106401">Universal relationship between magnetization and changes in the local structure of La<sub>1-x</sub>Ca<sub>x</sub>MnO<sub>3</sub>: evidence for magnetic dimers</a>
-					<p>L. Downward, F. Bridges, S. Bushart, J. J. Neumeier, N. Dilley, and L. Zhou </p>
-					<p>Phys. Rev. Lett. <strong>95</strong>, 106401 (2005)</p>
+				<div id="publication-container-local">
+					<a href="http://dx.doi.org/10.1103/PhysRevLett.87.095502">Nature of e<sub>g</sub> electron order in La<sub>1-x</sub>Sr<sub>1+x</sub>MnO<sub>4</sub></a>
+					<p>S. Larochelle, A. Mehta, N. Kaneko, P. K. Mang, A. F. Panchula, L. Zhou, J. Arthur, and M. Greven</p>
+					<p>Phys. Rev. Lett. <strong>87</strong>, 095502 (2001)</p>
 				</div>
 
-				<div id="publication-container-collab">
-					<a href="http://dx.doi.org/10.1038/nature02347">High-transition-temperature superconductivity in the absence of the magnetic-resonance mode</a>
-					<p>J. Hwang, T. Timusk, and G. D. Gu</p>
-					<p>Nature <strong>427</strong>, 714 (2004)</p>
-				</div>
 
 				<!-- END WEBSITE CONTENT -->
 			</div>


### PR DESCRIPTION
Sorted all publications in chronological order and added headings according to the publication year. Fixed some of the links to the online papers which seemed to be broken into 2 parts.
